### PR TITLE
Pass through existing initial data

### DIFF
--- a/hierarkey/forms.py
+++ b/hierarkey/forms.py
@@ -24,7 +24,9 @@ class HierarkeyForm(forms.Form):
         self.obj = obj
         self.attribute_name = attribute_name
         self._s = getattr(obj, attribute_name)
-        kwargs['initial'] = self._s.freeze()
+        initial = kwargs.pop('initial', {})
+        initial.update(self._s.freeze())
+        kwargs['initial'] = initial
         super().__init__(*args, **kwargs)
 
     def save(self) -> None:


### PR DESCRIPTION
This makes hierarkey easier to integrate with other types of forms or
fields, and allows mixins to provide additional fields within the same
form. This is sometimes preferable to having multiple forms in one
Django FormView.